### PR TITLE
Honor configured hostname in AWS trust

### DIFF
--- a/aws/trust/main.tf
+++ b/aws/trust/main.tf
@@ -27,10 +27,10 @@ resource "aws_iam_role" "tfc_role" {
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
-         "app.terraform.io:aud": "${one(aws_iam_openid_connect_provider.tfc_provider.client_id_list)}"
+         "${var.tfc_hostname}:aud": "${one(aws_iam_openid_connect_provider.tfc_provider.client_id_list)}"
        },
        "StringLike": {
-         "app.terraform.io:sub": "organization:${var.tfc_organization_name}:project:${var.tfc_project_name}:workspace:${var.tfc_workspace_name}:run_phase:*"
+         "${var.tfc_hostname}:sub": "organization:${var.tfc_organization_name}:project:${var.tfc_project_name}:workspace:${var.tfc_workspace_name}:run_phase:*"
        }
      }
    }


### PR DESCRIPTION
The AWS trust config created a role that hard-coded app.terraform.io as the hostname in conditions. This prevented dynamic credentials from working on staging or TFE instances.